### PR TITLE
fix detail a2c

### DIFF
--- a/a2c/main.py
+++ b/a2c/main.py
@@ -84,7 +84,7 @@ class Simulation(object):
             for trajectory in trajectories:
                 value, _ = self.master_agent.get_netowrk_outputs(torch.from_numpy(np.array([trajectory["s2"][-1]])).type(DTYPE) / 255.0)
                 if trajectory["dones"][-1] == 0:
-                    rewards = self._discounted_with_dones(trajectory["r"]+[value], trajectory["dones"]+[0])[:-1]
+                    rewards = self._discounted_with_dones(trajectory["r"]+[value.item()], trajectory["dones"]+[0])[:-1]
                 else:
                     rewards = self._discounted_with_dones(trajectory["r"], trajectory["dones"])
                 trajectory["R"] = rewards


### PR DESCRIPTION
## 概要
GPUで計算した際に下記のようなエラーが出たたためCPUでもGPUでも計算できるように修正した。
```
Traceback (most recent call last):
  File "main.py", line 150, in <module>
    Simulation().start()
  File "main.py", line 47, in start
    self.one_simulation_start(simulation_num)
  File "main.py", line 92, in one_simulation_start
    self.master_agent.learning(trajectories, n + 1)
  File "/home/ec2-user/workspace/deep-reinforcement-learning-list/a2c/agent.py", line 112, in learning
    discounted_returns = Variable(torch.from_numpy(np.array(discounted_returns, dtype=np.float32)))
  File "/home/ec2-user/myenv/lib/python3.7/site-packages/torch/tensor.py", line 623, in __array__
    return self.numpy().astype(dtype, copy=False)
TypeError: can't convert cuda:0 device type tensor to numpy. Use Tensor.cpu() to copy the tensor to host memory first.
```